### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -20,7 +20,7 @@ module "redis_operator" {
   repository           = var.chart_repository
   description          = var.chart_description
   chart_version        = var.chart_version
-  kubernetes_namespace = join("", kubernetes_namespace.default.*.id)
+  kubernetes_namespace = join("", kubernetes_namespace.default[*].id)
   create_namespace     = false
   wait                 = var.wait
   atomic               = var.atomic


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)